### PR TITLE
ZarrNET created debug log files as ordinary filesystem side effects.

### DIFF
--- a/LocalFileSystemStore.cs
+++ b/LocalFileSystemStore.cs
@@ -7,7 +7,6 @@ namespace ZarrNET.Core.Zarr.Store;
 public sealed class LocalFileSystemStore : IZarrStore, IDisposable
 {
     private static int s_debugCount = 0;
-    private static readonly string s_logPath = @"log.txt";
 
     private readonly string _rootPath;
     private bool _disposed;
@@ -174,13 +173,7 @@ public sealed class LocalFileSystemStore : IZarrStore, IDisposable
 
     private static void Log(string message)
     {
-        try
-        {
-            File.AppendAllText(s_logPath, message + Environment.NewLine);
-        }
-        catch
-        {
-        }
+        System.Diagnostics.Debug.WriteLine(message);
     }
 
     private static string SampleBytes(byte[] data, int count = 16)

--- a/Zarr.NET.sln
+++ b/Zarr.NET.sln
@@ -1,11 +1,8 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.2.11415.280
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zarr.NET", "Zarr.NET.csproj", "{FD9435AE-E546-2BAD-6EB8-38123063090D}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZarrTest", "..\ZarrTest\ZarrTest.csproj", "{B64F86F7-4E3C-4E82-8FDD-07C98FE45C61}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +14,6 @@ Global
 		{FD9435AE-E546-2BAD-6EB8-38123063090D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD9435AE-E546-2BAD-6EB8-38123063090D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD9435AE-E546-2BAD-6EB8-38123063090D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B64F86F7-4E3C-4E82-8FDD-07C98FE45C61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B64F86F7-4E3C-4E82-8FDD-07C98FE45C61}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B64F86F7-4E3C-4E82-8FDD-07C98FE45C61}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B64F86F7-4E3C-4E82-8FDD-07C98FE45C61}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ZarrArray.cs
+++ b/ZarrArray.cs
@@ -1,7 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
 using ZarrNET;
-using ZarrNET;
 using ZarrNET.Core.Zarr.Store;
 
 namespace ZarrNET.Core.Zarr;
@@ -24,7 +23,6 @@ public sealed class ZarrArray
     private static int s_readDebugCount = 0;
     private static readonly ConcurrentDictionary<string, byte> s_writePlaneProbeLogged = new(StringComparer.Ordinal);
     private static readonly ConcurrentDictionary<string, byte> s_readPlaneProbeLogged = new(StringComparer.Ordinal);
-    private static readonly string s_logPath = @"C:\Users\Public\biolog.txt";
 
     private readonly IZarrStore _store;
     private readonly string _arrayPath;   // store-relative path to the array root
@@ -705,13 +703,7 @@ public sealed class ZarrArray
 
     private static void Log(string message)
     {
-        try
-        {
-            File.AppendAllText(s_logPath, message + Environment.NewLine);
-        }
-        catch
-        {
-        }
+        System.Diagnostics.Debug.WriteLine(message);
     }
 
     private static string SampleBytes(byte[] data, int count = 16)


### PR DESCRIPTION
We observed files named `log.txt` and a Windows-style path fragment `C:\Users\Public\biolog.txt` being created relative to the current directory or application base directory. On a Macos system, like mine, that makes little sense.

Proposed solution:

Removed the hard-coded file log targets from LocalFileSystemStore.cs (line 174) and ZarrArray.cs (line 705).

Kept the diagnostics available via System.Diagnostics.Debug.WriteLine, matching the existing style in HttpZarrStore and avoiding filesystem side effects.

Removed the stale ZarrTest solution reference from Zarr.NET.sln (line 6), so VS Code should stop complaining about missing ..\ZarrTest\ZarrTest.csproj.