### PR TITLE
updated with float32 type support.

### DIFF
--- a/BytesCodec.cs
+++ b/BytesCodec.cs
@@ -60,8 +60,8 @@ public sealed class BytesCodec : IZarrCodec
     /// </summary>
     private static byte[] SwapByteOrder(byte[] input)
     {
-        // Default: swap every 2 bytes (uint16). CodecPipeline sets the real element size
-        // via the overload below before the pipeline runs.
+        // Default only applies if this codec is used directly. CodecPipeline
+        // supplies the real dtype element size through the overload below.
         return SwapByteOrder(input, elementSize: 2);
     }
 

--- a/OmeZarrWriter.cs
+++ b/OmeZarrWriter.cs
@@ -341,6 +341,11 @@ public sealed class OmeZarrWriter : IAsyncDisposable
             {
                 new
                 {
+                    name          = "bytes",
+                    configuration = new { endian = "little" }
+                },
+                new
+                {
                     name          = "blosc",
                     configuration = new
                     {

--- a/README.md
+++ b/README.md
@@ -240,6 +240,33 @@ var region = await level.ReadPixelRegionAsync(pixelRegion);
 await level.WriteRegionAsync(pixelRegion, data);
 ```
 
+#### Low-level chunk API
+For larger-than-memory and chunk-native workflows, open the underlying Zarr
+array and work directly with full chunks.
+
+```csharp
+await using var store = new LocalFileSystemStore("/path/to/data.zarr");
+var root = await ZarrGroup.OpenRootAsync(store);
+var array = await root.OpenArrayAsync("0");
+
+await foreach (var chunk in array.EnumerateChunksAsync())
+{
+    // Decoded path: full logical chunk buffer in array order.
+    byte[] decoded = await array.ReadChunkDecodedAsync(chunk);
+    await array.WriteChunkDecodedAsync(chunk, decoded);
+
+    // Encoded path: copy compressed bytes when metadata/codecs are compatible.
+    byte[]? encoded = await array.ReadChunkEncodedAsync(chunk);
+    if (encoded is not null)
+        await array.WriteChunkEncodedAsync(chunk, encoded);
+}
+```
+
+`ZarrChunkRef.Shape` gives the valid in-array extent for edge chunks. Decoded
+chunk buffers are padded to the full effective chunk shape, matching the region
+reader's fill-value behaviour. Encoded chunk access is available for non-sharded
+arrays; sharded arrays store logical chunks inside shard objects.
+
 #### `PlaneResult`
 Result of reading a 2D plane with convenience extraction methods.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,11 @@ The library is structured in clean, composable layers:
 ## Supported Features
 
 ### Data Types
-- `uint8`, `uint16`
+- `uint8`, `uint16`, `float32`
+
+The lower-level dtype parser also understands the core fixed-size integer and
+floating-point Zarr dtypes, including v2 NumPy dtype strings such as `"<f4"` and
+v3 data type names such as `"float32"`.
 
 ### Compression
 - **Gzip** - Standard compression (via System.IO.Compression)

--- a/V2_SUPPORT.md
+++ b/V2_SUPPORT.md
@@ -82,7 +82,9 @@ var data  = await level.ReadRegionAsync(roi);
 
 2. **Numpy dtypes**
    - v2: `"dtype": "<u2"` → little-endian uint16
+   - v2: `"dtype": "<f4"` → little-endian float32
    - v3: `"data_type": "uint16"` + `"endian": "little"` in bytes codec
+   - v3: `"data_type": "float32"` + `"endian": "little"` in bytes codec
 
 3. **Chunk keys**
    - v2: `0.1.2` (dimension_separator: ".")

--- a/ZarrArray.cs
+++ b/ZarrArray.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using ZarrNET;
 using ZarrNET.Core.Zarr.Store;
 
@@ -162,6 +163,126 @@ public sealed class ZarrArray
                 elementSize,
                 ct).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Enumerates every logical chunk in the array's regular chunk grid.
+    /// The returned chunk shape is clamped to the array extent for edge chunks.
+    /// </summary>
+    public async IAsyncEnumerable<ZarrChunkRef> EnumerateChunksAsync(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        if (Metadata.Shape.Any(s => s == 0))
+            yield break;
+
+        var start = new long[Metadata.Rank];
+        var end = (long[])Metadata.Shape.Clone();
+
+        await foreach (var chunk in EnumerateChunksAsync(start, end, ct).ConfigureAwait(false))
+            yield return chunk;
+    }
+
+    /// <summary>
+    /// Enumerates logical chunks intersecting the region [regionStart, regionEnd).
+    /// The returned chunk shape is clamped to both the array extent and edge chunks,
+    /// but not to the requested region; each reference identifies a whole chunk.
+    /// </summary>
+    public async IAsyncEnumerable<ZarrChunkRef> EnumerateChunksAsync(
+        long[] regionStart,
+        long[] regionEnd,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        ValidateRegion(regionStart, regionEnd);
+
+        foreach (var chunkCoord in EnumerateChunkCoordinates(regionStart, regionEnd))
+        {
+            ct.ThrowIfCancellationRequested();
+            yield return BuildChunkRef(chunkCoord);
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads and decodes a full logical chunk without routing through a region
+    /// output buffer. Missing chunks are returned as fill-value chunks.
+    ///
+    /// The returned buffer is padded to the full effective chunk shape used by
+    /// this array. Use <see cref="ZarrChunkRef.Shape"/> to identify the valid
+    /// in-array extent for edge chunks.
+    /// </summary>
+    public async Task<byte[]> ReadChunkDecodedAsync(
+        ZarrChunkRef chunk,
+        CancellationToken ct = default)
+    {
+        ValidateChunkRef(chunk);
+
+        var shardCache = Metadata.Sharding is not null
+            ? new ConcurrentDictionary<string, Task<byte[]?>>(StringComparer.Ordinal)
+            : null;
+
+        return await ReadChunkAsync(chunk.ChunkCoord, shardCache, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Encodes and writes a full logical chunk without read-modify-write.
+    /// The input must be a full effective chunk buffer, including fill-value
+    /// padding for any edge region outside the array extent.
+    /// </summary>
+    public async Task WriteChunkDecodedAsync(
+        ZarrChunkRef chunk,
+        byte[] decodedData,
+        CancellationToken ct = default)
+    {
+        if (Metadata.Sharding is not null)
+            throw new NotSupportedException(
+                "Decoded chunk writes are not supported for sharded arrays.");
+
+        ValidateChunkRef(chunk);
+
+        var expectedBytes = checked((int)(_chunkElementCount * Metadata.DataType.ElementSize));
+        if (decodedData.Length != expectedBytes)
+            throw new ArgumentException(
+                $"decodedData has {decodedData.Length} bytes, expected {expectedBytes} bytes " +
+                $"for full chunk shape [{string.Join(", ", _chunkShapeLong)}].",
+                nameof(decodedData));
+
+        await WriteChunkAsync(chunk.ChunkCoord, decodedData, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads the encoded bytes for a non-sharded chunk directly from the store.
+    /// Returns null when the chunk key is absent, matching Zarr fill-value
+    /// semantics for sparse chunks.
+    /// </summary>
+    public async Task<byte[]?> ReadChunkEncodedAsync(
+        ZarrChunkRef chunk,
+        CancellationToken ct = default)
+    {
+        EnsureNonShardedEncodedChunkAccess();
+        ValidateChunkRef(chunk);
+
+        var key = BuildChunkContainingStoreKey(chunk.ChunkCoord);
+        return await _store.ReadAsync(key, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Writes encoded bytes for a non-sharded chunk directly to the store.
+    /// Callers should only use this when the encoded bytes are compatible with
+    /// this array's metadata, chunk shape, dtype, and codec pipeline.
+    /// </summary>
+    public async Task WriteChunkEncodedAsync(
+        ZarrChunkRef chunk,
+        byte[] encodedData,
+        CancellationToken ct = default)
+    {
+        EnsureNonShardedEncodedChunkAccess();
+        ValidateChunkRef(chunk);
+
+        var key = BuildChunkContainingStoreKey(chunk.ChunkCoord);
+        await _store.WriteAsync(key, encodedData, ct).ConfigureAwait(false);
     }
 
     // -------------------------------------------------------------------------
@@ -559,6 +680,37 @@ public sealed class ZarrArray
         return IterateNdCoordinates(firstChunk, lastChunkExclusive, rank);
     }
 
+    private ZarrChunkRef BuildChunkRef(long[] chunkCoord)
+    {
+        var coord = (long[])chunkCoord.Clone();
+        var origin = ComputeChunkOrigin(coord);
+        var shape = ComputeTruncatedChunkShape(coord);
+        var key = BuildChunkContainingStoreKey(coord);
+
+        return new ZarrChunkRef(coord, origin, shape, key);
+    }
+
+    private string BuildChunkContainingStoreKey(long[] chunkCoord)
+    {
+        if (Metadata.Sharding is null)
+            return BuildChunkKey(chunkCoord);
+
+        var shardCoord = ComputeShardCoord(chunkCoord);
+        return BuildChunkKey(shardCoord);
+    }
+
+    private long[] ComputeShardCoord(long[] innerChunkCoord)
+    {
+        var sharding = Metadata.Sharding
+            ?? throw new InvalidOperationException("Array is not sharded.");
+
+        var shardCoord = new long[Metadata.Rank];
+        for (int d = 0; d < Metadata.Rank; d++)
+            shardCoord[d] = innerChunkCoord[d] / sharding.InnerChunksPerShard[d];
+
+        return shardCoord;
+    }
+
     private string BuildChunkKey(long[] chunkCoord)
     {
         var sep = Metadata.ChunkKeySeparator;
@@ -796,5 +948,40 @@ public sealed class ZarrArray
                 throw new ArgumentOutOfRangeException(
                     $"regionEnd[{d}] = {regionEnd[d]} is out of bounds ({regionStart[d]}, {Metadata.Shape[d]}].");
         }
+    }
+
+    private void ValidateChunkRef(ZarrChunkRef chunk)
+    {
+        var rank = Metadata.Rank;
+
+        if (chunk.ChunkCoord.Length != rank)
+            throw new ArgumentException(
+                $"ChunkCoord has {chunk.ChunkCoord.Length} dimensions, expected {rank}.",
+                nameof(chunk));
+
+        var chunkCounts = ComputeChunkCounts();
+        for (int d = 0; d < rank; d++)
+        {
+            if (chunk.ChunkCoord[d] < 0 || chunk.ChunkCoord[d] >= chunkCounts[d])
+                throw new ArgumentOutOfRangeException(
+                    nameof(chunk),
+                    $"ChunkCoord[{d}] = {chunk.ChunkCoord[d]} is out of bounds [0, {chunkCounts[d]}).");
+        }
+    }
+
+    private long[] ComputeChunkCounts()
+    {
+        var counts = new long[Metadata.Rank];
+        for (int d = 0; d < Metadata.Rank; d++)
+            counts[d] = (Metadata.Shape[d] + _chunkShapeLong[d] - 1) / _chunkShapeLong[d];
+        return counts;
+    }
+
+    private void EnsureNonShardedEncodedChunkAccess()
+    {
+        if (Metadata.Sharding is not null)
+            throw new NotSupportedException(
+                "Encoded chunk access is not supported for sharded arrays because " +
+                "logical inner chunks are stored inside shard objects.");
     }
 }

--- a/ZarrArray.cs
+++ b/ZarrArray.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using ZarrNET;
 using ZarrNET.Core.Zarr.Store;
 
@@ -235,6 +236,21 @@ public sealed class ZarrArray
         ZarrChunkRef chunk,
         byte[] decodedData,
         CancellationToken ct = default)
+        => await WriteChunkDecodedAsync(
+            chunk,
+            decodedData.AsMemory(),
+            ct).ConfigureAwait(false);
+
+    /// <summary>
+    /// Encodes and writes a full logical chunk without read-modify-write.
+    /// The input memory length must be the full effective chunk byte count.
+    /// Pooled buffers may be passed as a sliced memory region; the memory is
+    /// consumed or copied before the returned task completes.
+    /// </summary>
+    public async Task WriteChunkDecodedAsync(
+        ZarrChunkRef chunk,
+        ReadOnlyMemory<byte> decodedData,
+        CancellationToken ct = default)
     {
         if (Metadata.Sharding is not null)
             throw new NotSupportedException(
@@ -249,7 +265,10 @@ public sealed class ZarrArray
                 $"for full chunk shape [{string.Join(", ", _chunkShapeLong)}].",
                 nameof(decodedData));
 
-        await WriteChunkAsync(chunk.ChunkCoord, decodedData, ct).ConfigureAwait(false);
+        await WriteChunkAsync(
+            chunk.ChunkCoord,
+            ToExactArray(decodedData),
+            ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -277,12 +296,26 @@ public sealed class ZarrArray
         ZarrChunkRef chunk,
         byte[] encodedData,
         CancellationToken ct = default)
+        => await WriteChunkEncodedAsync(
+            chunk,
+            encodedData.AsMemory(),
+            ct).ConfigureAwait(false);
+
+    /// <summary>
+    /// Writes encoded bytes for a non-sharded chunk directly to the store.
+    /// Pooled buffers may be passed as a sliced memory region; the memory is
+    /// consumed or copied before the returned task completes.
+    /// </summary>
+    public async Task WriteChunkEncodedAsync(
+        ZarrChunkRef chunk,
+        ReadOnlyMemory<byte> encodedData,
+        CancellationToken ct = default)
     {
         EnsureNonShardedEncodedChunkAccess();
         ValidateChunkRef(chunk);
 
         var key = BuildChunkContainingStoreKey(chunk.ChunkCoord);
-        await _store.WriteAsync(key, encodedData, ct).ConfigureAwait(false);
+        await _store.WriteAsync(key, ToExactArray(encodedData), ct).ConfigureAwait(false);
     }
 
     // -------------------------------------------------------------------------
@@ -448,20 +481,6 @@ public sealed class ZarrArray
             Log($"[ZarrArray.WriteChunkAsync] chunk={string.Join(",", chunkCoord)} encodedLen={encoded.Length} " +
                 $"encodedSample={SampleBytes(encoded)}");
             s_writeDebugCount++;
-        }
-
-        try
-        {
-            var roundTrip = await _pipeline.DecodeAsync(encoded, ct).ConfigureAwait(false);
-            if (s_writeDebugCount <= 8)
-            {
-                Log($"[ZarrArray.WriteChunkAsync.RoundTrip] chunk={string.Join(",", chunkCoord)} roundTripLen={roundTrip.Length} " +
-                    $"roundTripSample={SampleBytes(roundTrip)} roundTripU16={SampleU16(roundTrip)}");
-            }
-        }
-        catch (Exception ex)
-        {
-            Log($"[ZarrArray.WriteChunkAsync.RoundTrip] chunk={string.Join(",", chunkCoord)} EXCEPTION {ex.GetType().Name}: {ex.Message}");
         }
 
         await _store.WriteAsync(key, encoded, ct).ConfigureAwait(false);
@@ -852,6 +871,19 @@ public sealed class ZarrArray
 
     private static long ComputeTotalElements(long[] shape)
         => shape.Aggregate(1L, (acc, s) => acc * s);
+
+    private static byte[] ToExactArray(ReadOnlyMemory<byte> data)
+    {
+        if (MemoryMarshal.TryGetArray(data, out ArraySegment<byte> segment) &&
+            segment.Array is not null &&
+            segment.Offset == 0 &&
+            segment.Count == segment.Array.Length)
+        {
+            return segment.Array;
+        }
+
+        return data.ToArray();
+    }
 
     private static void Log(string message)
     {

--- a/ZarrChunkRef.cs
+++ b/ZarrChunkRef.cs
@@ -1,0 +1,13 @@
+namespace ZarrNET.Core.Zarr;
+
+/// <summary>
+/// Identifies one logical chunk of a Zarr array.
+/// ChunkCoord is the chunk-grid coordinate, Origin is the array element origin,
+/// Shape is the valid element shape within the array extent, and Key is the
+/// store key containing the encoded chunk bytes.
+/// </summary>
+public readonly record struct ZarrChunkRef(
+    long[] ChunkCoord,
+    long[] Origin,
+    long[] Shape,
+    string Key);

--- a/ZstdCodec.cs
+++ b/ZstdCodec.cs
@@ -13,10 +13,10 @@ public sealed class ZstdCodec : IZarrCodec
 
     private readonly int _level;
 
-    /// <param name="level">Compression level 1–22. Default 3 matches zstd's default.</param>
+    /// <param name="level">Compression level 0–22. Default 3 matches zstd's default.</param>
     public ZstdCodec(int level = 3)
     {
-        _level = Math.Clamp(level, 1, 22);
+        _level = Math.Clamp(level, 0, 22);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
There seems to be no test suite in this project, but I've made a series of user-test for single-scale zarr images and have yet to discover bugs. I'm still new to programming Zarr internals, so I could worry about whether I've, e.g., done the endianness correctly.