### PR TITLE
Add float64 and complex dtype support

### DIFF
--- a/CodecFactory.cs
+++ b/CodecFactory.cs
@@ -26,14 +26,14 @@ public static class CodecFactory
             metadata.Sharding = shardingConfig;
 
             // Return an empty pipeline — ZarrArray will use ShardReader directly
-            return new CodecPipeline(Array.Empty<IZarrCodec>(), metadata.DataType.ElementSize);
+            return new CodecPipeline(Array.Empty<IZarrCodec>(), metadata.DataType.ByteOrderElementSize);
         }
 
         var codecs = metadata.Codecs
             .Select(info => BuildCodec(info))
             .ToList();
 
-        return new CodecPipeline(codecs, metadata.DataType.ElementSize);
+        return new CodecPipeline(codecs, metadata.DataType.ByteOrderElementSize);
     }
 
     // -------------------------------------------------------------------------
@@ -146,7 +146,7 @@ public static class CodecFactory
             : Array.Empty<CodecInfo>();
 
         var innerCodecs = innerCodecInfos.Select(BuildCodec).ToList();
-        var innerPipeline = new CodecPipeline(innerCodecs, metadata.DataType.ElementSize);
+        var innerPipeline = new CodecPipeline(innerCodecs, metadata.DataType.ByteOrderElementSize);
 
         // Index codecs — the pipeline applied to the binary shard index
         var indexCodecInfos = cfg.TryGetProperty("index_codecs", out var indexCodecsProp)
@@ -155,7 +155,7 @@ public static class CodecFactory
 
         var indexCodecs = indexCodecInfos.Select(BuildCodec).ToList();
         // Index entries are uint64 pairs — element size is 8 bytes
-        var indexPipeline = new CodecPipeline(indexCodecs, elementSize: 8);
+        var indexPipeline = new CodecPipeline(indexCodecs, byteOrderElementSize: 8);
 
         // Index location
         var indexLocationStr = cfg.TryGetProperty("index_location", out var locProp)

--- a/CodecPipeline.cs
+++ b/CodecPipeline.cs
@@ -8,7 +8,8 @@ namespace ZarrNET;
 ///   Encode: first codec → ... → last codec   (array bytes → compressed bytes)
 ///
 /// The pipeline also resolves byte-order swapping for the BytesCodec based on
-/// the data type element size from ZarrArrayMetadata.
+/// the data type byte-order element size from ZarrArrayMetadata. For complex
+/// dtypes this is the real/imag component size, not the full complex size.
 ///
 /// When all codecs in the pipeline are synchronous (returning completed Tasks),
 /// the decode/encode path avoids async state machine overhead entirely. This is
@@ -17,13 +18,13 @@ namespace ZarrNET;
 public sealed class CodecPipeline
 {
     private readonly IReadOnlyList<IZarrCodec> _codecs;
-    private readonly int _elementSize;
+    private readonly int _byteOrderElementSize;
     private readonly bool _allCodecsSync;
 
-    public CodecPipeline(IReadOnlyList<IZarrCodec> codecs, int elementSize)
+    public CodecPipeline(IReadOnlyList<IZarrCodec> codecs, int byteOrderElementSize)
     {
-        _codecs      = codecs;
-        _elementSize = elementSize;
+        _codecs               = codecs;
+        _byteOrderElementSize = byteOrderElementSize;
 
         // Detect whether every codec in the pipeline is synchronous.
         // Synchronous codecs return Task.FromResult — we identify them by
@@ -116,7 +117,7 @@ public sealed class CodecPipeline
     private byte[] ApplyDecodeStepSync(IZarrCodec codec, byte[] data, CancellationToken ct)
     {
         if (codec is BytesCodec bytesCodec)
-            return bytesCodec.DecodeWithElementSizeAsync(data, _elementSize, ct).GetAwaiter().GetResult();
+            return bytesCodec.DecodeWithElementSizeAsync(data, _byteOrderElementSize, ct).GetAwaiter().GetResult();
 
         // All non-Gzip codecs return completed tasks, so .Result is safe
         return codec.DecodeAsync(data, ct).GetAwaiter().GetResult();
@@ -125,7 +126,7 @@ public sealed class CodecPipeline
     private byte[] ApplyEncodeStepSync(IZarrCodec codec, byte[] data, CancellationToken ct)
     {
         if (codec is BytesCodec bytesCodec)
-            return bytesCodec.EncodeWithElementSizeAsync(data, _elementSize, ct).GetAwaiter().GetResult();
+            return bytesCodec.EncodeWithElementSizeAsync(data, _byteOrderElementSize, ct).GetAwaiter().GetResult();
 
         return codec.EncodeAsync(data, ct).GetAwaiter().GetResult();
     }
@@ -136,16 +137,16 @@ public sealed class CodecPipeline
 
     private Task<byte[]> ApplyDecodeStepAsync(IZarrCodec codec, byte[] data, CancellationToken ct)
     {
-        // BytesCodec needs element size to handle endianness correctly
+        // BytesCodec needs byte-order element size to handle endianness correctly.
         if (codec is BytesCodec bytesCodec)
-            return bytesCodec.DecodeWithElementSizeAsync(data, _elementSize, ct);
+            return bytesCodec.DecodeWithElementSizeAsync(data, _byteOrderElementSize, ct);
         return codec.DecodeAsync(data, ct);
     }
 
     private Task<byte[]> ApplyEncodeStepAsync(IZarrCodec codec, byte[] data, CancellationToken ct)
     {
         if (codec is BytesCodec bytesCodec)
-            return bytesCodec.EncodeWithElementSizeAsync(data, _elementSize, ct);
+            return bytesCodec.EncodeWithElementSizeAsync(data, _byteOrderElementSize, ct);
 
         return codec.EncodeAsync(data, ct);
     }

--- a/NumpyDtypeParser.cs
+++ b/NumpyDtypeParser.cs
@@ -4,9 +4,9 @@ namespace ZarrNET;
 /// Parses numpy-style dtype strings used in Zarr v2.
 /// Format: [byteorder][typecode][size]
 ///   byteorder: '<' (little), '>' (big), '|' (not applicable)
-///   typecode:  'u' (uint), 'i' (int), 'f' (float), 'b' (bool)
-///   size:      number of bytes (1, 2, 4, 8)
-/// Examples: "<u2" → little-endian uint16, ">f4" → big-endian float32, "<f8" → float64, "|u1" → uint8
+///   typecode:  'u' (uint), 'i' (int), 'f' (float), 'c' (complex), 'b' (bool)
+///   size:      number of bytes (1, 2, 4, 8, 16)
+/// Examples: "<u2" → uint16, ">f4" → big-endian float32, "<c8" → complex64, "<c16" → complex128
 /// </summary>
 public static class NumpyDtypeParser
 {
@@ -62,6 +62,8 @@ public static class NumpyDtypeParser
             ('i', 8) => ZarrDataType.Parse("int64"),
             ('f', 4) => ZarrDataType.Parse("float32"),
             ('f', 8) => ZarrDataType.Parse("float64"),
+            ('c', 8) => ZarrDataType.Parse("complex64"),
+            ('c', 16) => ZarrDataType.Parse("complex128"),
             _        => throw new NotSupportedException(
                             $"Unsupported numpy dtype: type='{typeCode}', size={size} bytes")
         };

--- a/NumpyDtypeParser.cs
+++ b/NumpyDtypeParser.cs
@@ -6,7 +6,7 @@ namespace ZarrNET;
 ///   byteorder: '<' (little), '>' (big), '|' (not applicable)
 ///   typecode:  'u' (uint), 'i' (int), 'f' (float), 'b' (bool)
 ///   size:      number of bytes (1, 2, 4, 8)
-/// Examples: "<u2" → little-endian uint16, ">f4" → big-endian float32, "|u1" → uint8
+/// Examples: "<u2" → little-endian uint16, ">f4" → big-endian float32, "<f8" → float64, "|u1" → uint8
 /// </summary>
 public static class NumpyDtypeParser
 {

--- a/OmeZarrWriter.cs
+++ b/OmeZarrWriter.cs
@@ -12,6 +12,12 @@ namespace ZarrNET.Core;
 // Image descriptor — caller fills this in before handing off to the writer
 // =============================================================================
 
+public enum ZarrCompression
+{
+    BloscLz4,
+    None
+}
+
 /// <summary>
 /// Everything the writer needs to know about a 5D image being saved.
 /// Shape is always interpreted as (T, C, Z, Y, X) in this descriptor.
@@ -21,6 +27,7 @@ public class BioImageDescriptor
 {
     public string Name     { get; init; } = "image";
     public string DataType { get; init; } = "uint16";
+    public ZarrCompression Compression { get; init; } = ZarrCompression.BloscLz4;
 
     public int SizeT { get; }
     public int SizeC { get; }
@@ -337,29 +344,44 @@ public sealed class OmeZarrWriter : IAsyncDisposable
             },
             fill_value      = 0,
             dimension_names = new[] { "t", "c", "z", "y", "x" },
-            codecs          = new object[]
+            codecs          = BuildArrayCodecs(d.Compression, elementSize)
+        };
+
+        await WriteJsonAsync(store, $"{levelIndex}/zarr.json", arrayDoc, ct).ConfigureAwait(false);
+    }
+
+    private static object[] BuildArrayCodecs(ZarrCompression compression, int elementSize)
+    {
+        var bytesCodec = new
+        {
+            name          = "bytes",
+            configuration = new { endian = "little" }
+        };
+
+        return compression switch
+        {
+            ZarrCompression.BloscLz4 => new object[]
             {
-                new
-                {
-                    name          = "bytes",
-                    configuration = new { endian = "little" }
-                },
+                bytesCodec,
                 new
                 {
                     name          = "blosc",
                     configuration = new
                     {
-                        cname    = "lz4",
-                        clevel   = 5,
-                        shuffle  = "byteshuffle",
-                        typesize = elementSize,
-                        blocksize= 0
+                        cname     = "lz4",
+                        clevel    = 5,
+                        shuffle   = "byteshuffle",
+                        typesize  = elementSize,
+                        blocksize = 0
                     }
                 }
-            }
-        };
+            },
 
-        await WriteJsonAsync(store, $"{levelIndex}/zarr.json", arrayDoc, ct).ConfigureAwait(false);
+            ZarrCompression.None => new object[] { bytesCodec },
+
+            _ => throw new NotSupportedException(
+                $"Unsupported Zarr compression option: {compression}.")
+        };
     }
 
     private static async Task WriteJsonAsync(IZarrStore store, string key, object document, CancellationToken ct)

--- a/README.md
+++ b/README.md
@@ -180,11 +180,11 @@ The library is structured in clean, composable layers:
 ## Supported Features
 
 ### Data Types
-- `uint8`, `uint16`, `float32`
+- `uint8`, `uint16`, `float32`, `float64`
 
 The lower-level dtype parser also understands the core fixed-size integer and
-floating-point Zarr dtypes, including v2 NumPy dtype strings such as `"<f4"` and
-v3 data type names such as `"float32"`.
+floating-point Zarr dtypes, including v2 NumPy dtype strings such as `"<f4"` /
+`"<f8"` and v3 data type names such as `"float32"` / `"float64"`.
 
 ### Compression
 - **Gzip** - Standard compression (via System.IO.Compression)

--- a/README.md
+++ b/README.md
@@ -180,11 +180,12 @@ The library is structured in clean, composable layers:
 ## Supported Features
 
 ### Data Types
-- `uint8`, `uint16`, `float32`, `float64`
+- `uint8`, `uint16`, `float32`, `float64`, `complex64`, `complex128`
 
 The lower-level dtype parser also understands the core fixed-size integer and
 floating-point Zarr dtypes, including v2 NumPy dtype strings such as `"<f4"` /
-`"<f8"` and v3 data type names such as `"float32"` / `"float64"`.
+`"<f8"` / `"<c8"` / `"<c16"` and v3 data type names such as `"float32"` /
+`"float64"` / `"complex64"` / `"complex128"`.
 
 ### Compression
 - **Gzip** - Standard compression (via System.IO.Compression)

--- a/V2_SUPPORT.md
+++ b/V2_SUPPORT.md
@@ -84,9 +84,13 @@ var data  = await level.ReadRegionAsync(roi);
    - v2: `"dtype": "<u2"` → little-endian uint16
    - v2: `"dtype": "<f4"` → little-endian float32
    - v2: `"dtype": "<f8"` → little-endian float64
+   - v2: `"dtype": "<c8"` → little-endian complex64
+   - v2: `"dtype": "<c16"` → little-endian complex128
    - v3: `"data_type": "uint16"` + `"endian": "little"` in bytes codec
    - v3: `"data_type": "float32"` + `"endian": "little"` in bytes codec
    - v3: `"data_type": "float64"` + `"endian": "little"` in bytes codec
+   - v3: `"data_type": "complex64"` + `"endian": "little"` in bytes codec
+   - v3: `"data_type": "complex128"` + `"endian": "little"` in bytes codec
 
 3. **Chunk keys**
    - v2: `0.1.2` (dimension_separator: ".")

--- a/V2_SUPPORT.md
+++ b/V2_SUPPORT.md
@@ -83,8 +83,10 @@ var data  = await level.ReadRegionAsync(roi);
 2. **Numpy dtypes**
    - v2: `"dtype": "<u2"` → little-endian uint16
    - v2: `"dtype": "<f4"` → little-endian float32
+   - v2: `"dtype": "<f8"` → little-endian float64
    - v3: `"data_type": "uint16"` + `"endian": "little"` in bytes codec
    - v3: `"data_type": "float32"` + `"endian": "little"` in bytes codec
+   - v3: `"data_type": "float64"` + `"endian": "little"` in bytes codec
 
 3. **Chunk keys**
    - v2: `0.1.2` (dimension_separator: ".")

--- a/ZarrDataType.cs
+++ b/ZarrDataType.cs
@@ -1,7 +1,7 @@
 namespace ZarrNET;
 
 /// <summary>
-/// Typed representation of a Zarr v3 data type string (e.g. "uint8", "float32").
+/// Typed representation of a Zarr v3 data type string (e.g. "uint8", "float32", "float64").
 /// Resolves element size in bytes and provides type classification used
 /// by the codec pipeline for byte-order handling.
 /// </summary>

--- a/ZarrDataType.cs
+++ b/ZarrDataType.cs
@@ -1,7 +1,7 @@
 namespace ZarrNET;
 
 /// <summary>
-/// Typed representation of a Zarr v3 data type string (e.g. "uint8", "float32", "float64").
+/// Typed representation of a Zarr v3 data type string (e.g. "uint8", "float32", "complex64").
 /// Resolves element size in bytes and provides type classification used
 /// by the codec pipeline for byte-order handling.
 /// </summary>
@@ -9,18 +9,53 @@ public sealed class ZarrDataType
 {
     public string TypeString { get; }
     public int    ElementSize { get; }
+    public int    ByteOrderElementSize { get; }
     public bool   IsFloat     { get; }
     public bool   IsInteger   { get; }
+    public bool   IsComplex   { get; }
     public bool   IsSigned    { get; }
 
-    private ZarrDataType(string typeString, int elementSize, bool isFloat, bool isSigned)
+    private ZarrDataType(
+        string typeString,
+        int elementSize,
+        int byteOrderElementSize,
+        bool isFloat,
+        bool isComplex,
+        bool isSigned)
     {
-        TypeString  = typeString;
-        ElementSize = elementSize;
-        IsFloat     = isFloat;
-        IsInteger   = !isFloat;
-        IsSigned    = isSigned;
+        TypeString           = typeString;
+        ElementSize          = elementSize;
+        ByteOrderElementSize = byteOrderElementSize;
+        IsFloat              = isFloat;
+        IsComplex            = isComplex;
+        IsInteger            = !isFloat && !isComplex;
+        IsSigned             = isSigned;
     }
+
+    private static ZarrDataType Numeric(
+        string typeString,
+        int elementSize,
+        bool isFloat,
+        bool isSigned)
+        => new(
+            typeString,
+            elementSize,
+            byteOrderElementSize: elementSize,
+            isFloat,
+            isComplex: false,
+            isSigned);
+
+    private static ZarrDataType Complex(
+        string typeString,
+        int elementSize,
+        int componentSize)
+        => new(
+            typeString,
+            elementSize,
+            byteOrderElementSize: componentSize,
+            isFloat: false,
+            isComplex: true,
+            isSigned: true);
 
     // -------------------------------------------------------------------------
     // Parsing
@@ -30,17 +65,19 @@ public sealed class ZarrDataType
     {
         return typeString switch
         {
-            "bool"    => new ZarrDataType(typeString, 1, isFloat: false, isSigned: false),
-            "int8"    => new ZarrDataType(typeString, 1, isFloat: false, isSigned: true),
-            "uint8"   => new ZarrDataType(typeString, 1, isFloat: false, isSigned: false),
-            "int16"   => new ZarrDataType(typeString, 2, isFloat: false, isSigned: true),
-            "uint16"  => new ZarrDataType(typeString, 2, isFloat: false, isSigned: false),
-            "int32"   => new ZarrDataType(typeString, 4, isFloat: false, isSigned: true),
-            "uint32"  => new ZarrDataType(typeString, 4, isFloat: false, isSigned: false),
-            "int64"   => new ZarrDataType(typeString, 8, isFloat: false, isSigned: true),
-            "uint64"  => new ZarrDataType(typeString, 8, isFloat: false, isSigned: false),
-            "float32" => new ZarrDataType(typeString, 4, isFloat: true,  isSigned: true),
-            "float64" => new ZarrDataType(typeString, 8, isFloat: true,  isSigned: true),
+            "bool"       => Numeric(typeString, 1, isFloat: false, isSigned: false),
+            "int8"       => Numeric(typeString, 1, isFloat: false, isSigned: true),
+            "uint8"      => Numeric(typeString, 1, isFloat: false, isSigned: false),
+            "int16"      => Numeric(typeString, 2, isFloat: false, isSigned: true),
+            "uint16"     => Numeric(typeString, 2, isFloat: false, isSigned: false),
+            "int32"      => Numeric(typeString, 4, isFloat: false, isSigned: true),
+            "uint32"     => Numeric(typeString, 4, isFloat: false, isSigned: false),
+            "int64"      => Numeric(typeString, 8, isFloat: false, isSigned: true),
+            "uint64"     => Numeric(typeString, 8, isFloat: false, isSigned: false),
+            "float32"    => Numeric(typeString, 4, isFloat: true,  isSigned: true),
+            "float64"    => Numeric(typeString, 8, isFloat: true,  isSigned: true),
+            "complex64"  => Complex(typeString, 8, componentSize: 4),
+            "complex128" => Complex(typeString, 16, componentSize: 8),
             _ => throw new NotSupportedException($"Unsupported Zarr data type: '{typeString}'")
         };
     }


### PR DESCRIPTION
I've added support for the remaining core numeric Zarr dtypes: float64, complex64, and complex128.

Changes include:
- document float64 support and v2/v3 dtype examples
- parse v2 NumPy complex dtype strings c8 and c16
- parse v3 complex64 and complex128 data_type values
- handle complex byte-order conversion by real/imag component size rather than full complex element size

We should make an actual test suite. So far I've made small temporary test for complex dtype parsing and bytes-codec endian handling. I'm actively using the library in another project, i.e., I'm doing simple use-based testing, but it cannot replace a more thorough unit test, and with endianness, my mac usage is probably one-sided.