### PR TITLE
Warnings issued when compiling, some of them potentially worrying

### DIFF
--- a/BytesCodec.cs
+++ b/BytesCodec.cs
@@ -52,6 +52,8 @@ public sealed class BytesCodec : IZarrCodec
         => _byteOrder == ByteOrder.BigEndian && BitConverter.IsLittleEndian
         || _byteOrder == ByteOrder.LittleEndian && !BitConverter.IsLittleEndian;
 
+    internal bool IsNoOpForHostByteOrder => !NeedsSwap();
+
     /// <summary>
     /// Reverses byte order for each element. We rely on the element size being
     /// provided by the zarr data type — but BytesCodec at this layer operates on

--- a/CodecPipeline.cs
+++ b/CodecPipeline.cs
@@ -33,6 +33,17 @@ public sealed class CodecPipeline
         _allCodecsSync = codecs.All(c => c is not GzipCodec);
     }
 
+    /// <summary>
+    /// True when encoded storage bytes are identical to decoded in-memory array bytes.
+    /// This allows whole-chunk IO to bypass byte-array materialization without
+    /// skipping any Zarr-required transform.
+    /// </summary>
+    public bool CanStoreDecodedBytesWithoutTransform
+        => _codecs.Count == 0
+        || _codecs.Count == 1
+        && _codecs[0] is BytesCodec bytesCodec
+        && bytesCodec.IsNoOpForHostByteOrder;
+
     // -------------------------------------------------------------------------
     // Pipeline execution
     // -------------------------------------------------------------------------

--- a/DiagnoseChunkFiles.cs
+++ b/DiagnoseChunkFiles.cs
@@ -43,8 +43,11 @@ namespace ZarrNET
             if (zarrayExists)
             {
                 var zarrayBytes = await store.ReadAsync(zarrayPath);
-                var zarrayJson = System.Text.Encoding.UTF8.GetString(zarrayBytes);
-                Console.WriteLine($"\n.zarray contents:\n{zarrayJson}");
+                if (zarrayBytes is not null)
+                {
+                    var zarrayJson = System.Text.Encoding.UTF8.GetString(zarrayBytes);
+                    Console.WriteLine($"\n.zarray contents:\n{zarrayJson}");
+                }
             }
 
             // Try to find some actual chunk files

--- a/HttpZarrStore.cs
+++ b/HttpZarrStore.cs
@@ -315,6 +315,11 @@ public sealed class HttpZarrStore : IZarrStore
 
     public async Task WriteAsync(string key, byte[] data, CancellationToken ct = default)
     {
+        await WriteAsync(key, data.AsMemory(), ct).ConfigureAwait(false);
+    }
+
+    public Task WriteAsync(string key, ReadOnlyMemory<byte> data, CancellationToken ct = default)
+    {
         ThrowIfDisposed();
 
         throw new NotSupportedException(

--- a/HttpZarrStore.cs
+++ b/HttpZarrStore.cs
@@ -206,7 +206,7 @@ public sealed class HttpZarrStore : IZarrStore
             _httpClient = CreateDefaultHttpClient();
             goto A;
         }
-        catch (TaskCanceledException ex)
+        catch (TaskCanceledException)
         {
             retry++;
             if (retry >= MaxRetries) return null;

--- a/IZarrStore.cs
+++ b/IZarrStore.cs
@@ -10,8 +10,31 @@ public interface IZarrStore : IAsyncDisposable
     /// <summary>Reads raw bytes for a key. Returns null if the key does not exist.</summary>
     Task<byte[]?> ReadAsync(string key, CancellationToken ct = default);
 
+    /// <summary>Reads raw bytes into caller-owned memory. Returns null if the key does not exist.</summary>
+    async Task<int?> ReadAsync(string key, Memory<byte> destination, CancellationToken ct = default)
+    {
+        var data = await ReadAsync(key, ct).ConfigureAwait(false);
+        if (data is null)
+            return null;
+
+        if (data.Length > destination.Length)
+            throw new ArgumentException(
+                $"Destination has {destination.Length} bytes, but key '{key}' contains {data.Length} bytes.",
+                nameof(destination));
+
+        data.CopyTo(destination);
+        return data.Length;
+    }
+
     /// <summary>Writes raw bytes to a key, creating it if it does not exist.</summary>
     Task WriteAsync(string key, byte[] data, CancellationToken ct = default);
+
+    /// <summary>
+    /// Writes raw bytes to a key, creating it if it does not exist. Implementations
+    /// must consume the memory before the returned task completes.
+    /// </summary>
+    Task WriteAsync(string key, ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        => WriteAsync(key, data.ToArray(), ct);
 
     /// <summary>Returns true if the key exists in the store.</summary>
     Task<bool> ExistsAsync(string key, CancellationToken ct = default);

--- a/LocalFileSystemStore.cs
+++ b/LocalFileSystemStore.cs
@@ -48,7 +48,49 @@ public sealed class LocalFileSystemStore : IZarrStore, IDisposable
         return data;
     }
 
+    public async Task<int?> ReadAsync(string key, Memory<byte> destination, CancellationToken ct = default)
+    {
+        ThrowIfDisposed();
+
+        var fullPath = ResolveKey(key);
+
+        if (!File.Exists(fullPath))
+            return null;
+
+        var length = checked((int)new FileInfo(fullPath).Length);
+        if (length > destination.Length)
+            throw new ArgumentException(
+                $"Destination has {destination.Length} bytes, but key '{key}' contains {length} bytes.",
+                nameof(destination));
+
+        await using var stream = new FileStream(
+            fullPath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize: 1024 * 1024,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        var offset = 0;
+        while (offset < length)
+        {
+            var read = await stream.ReadAsync(destination[offset..length], ct).ConfigureAwait(false);
+            if (read == 0)
+                throw new IOException(
+                    $"Short read for '{fullPath}': expected {length} bytes but received {offset} bytes.");
+
+            offset += read;
+        }
+
+        return length;
+    }
+
     public async Task WriteAsync(string key, byte[] data, CancellationToken ct = default)
+    {
+        await WriteAsync(key, data.AsMemory(), ct).ConfigureAwait(false);
+    }
+
+    public async Task WriteAsync(string key, ReadOnlyMemory<byte> data, CancellationToken ct = default)
     {
         ThrowIfDisposed();
 
@@ -57,7 +99,16 @@ public sealed class LocalFileSystemStore : IZarrStore, IDisposable
 
         Directory.CreateDirectory(directory);
 
-        await File.WriteAllBytesAsync(fullPath, data, ct).ConfigureAwait(false);
+        await using (var stream = new FileStream(
+            fullPath,
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.None,
+            bufferSize: 1024 * 1024,
+            FileOptions.Asynchronous | FileOptions.SequentialScan))
+        {
+            await stream.WriteAsync(data, ct).ConfigureAwait(false);
+        }
 
         if (s_debugCount < 16)
         {
@@ -177,5 +228,11 @@ public sealed class LocalFileSystemStore : IZarrStore, IDisposable
     }
 
     private static string SampleBytes(byte[] data, int count = 16)
-        => string.Join(",", data.Take(Math.Min(count, data.Length)));
+        => SampleBytes(data.AsSpan(), count);
+
+    private static string SampleBytes(ReadOnlyMemory<byte> data, int count = 16)
+        => SampleBytes(data.Span, count);
+
+    private static string SampleBytes(ReadOnlySpan<byte> data, int count = 16)
+        => string.Join(",", data[..Math.Min(count, data.Length)].ToArray());
 }

--- a/OmeZarrNodes.cs
+++ b/OmeZarrNodes.cs
@@ -233,7 +233,8 @@ public sealed class ResolutionLevelNode
     /// <param name="c">Channel index (0-based).</param>
     /// <param name="z">Z-slice index (0-based).</param>
     /// <param name="ct">Cancellation token.</param>
-    public async Task<RegionResult> ReadTileAsync(
+    /// <returns>The tile region, or null when the tile starts outside the image extent.</returns>
+    public async Task<RegionResult?> ReadTileAsync(
         int tileOriginX,
         int tileOriginY,
         int tileSizeX,

--- a/OmeZarrWriter.cs
+++ b/OmeZarrWriter.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using ZarrNET.Core;
 using ZarrNET;
-using ZarrNET.Core;
 using ZarrNET.Core.Zarr;
 using ZarrNET.Core.Zarr.Store;
 

--- a/PropertyReferenceGuide.cs
+++ b/PropertyReferenceGuide.cs
@@ -13,7 +13,7 @@ namespace ZarrNET
 {
     public class PropertyReferanceGuide()
     {
-        public static MultiscaleNode image;
+        public static MultiscaleNode image = null!;
         // =============================================================================
         // ResolutionLevelNode - Array-level properties
         // =============================================================================

--- a/README.md
+++ b/README.md
@@ -256,6 +256,25 @@ await foreach (var chunk in array.EnumerateChunksAsync())
     byte[] decoded = await array.ReadChunkDecodedAsync(chunk);
     await array.WriteChunkDecodedAsync(chunk, decoded);
 
+    // Caller-owned buffer path for uncompressed/native-endian bytes chunks.
+    byte[] rented = ArrayPool<byte>.Shared.Rent(decoded.Length);
+    try
+    {
+        await array.ReadChunkDecodedAsync(
+            chunk,
+            rented.AsMemory(0, decoded.Length),
+            allowBorrowedBuffer: true);
+
+        await array.WriteChunkDecodedAsync(
+            chunk,
+            rented.AsMemory(0, decoded.Length),
+            allowBorrowedBuffer: true);
+    }
+    finally
+    {
+        ArrayPool<byte>.Shared.Return(rented);
+    }
+
     // Encoded path: copy compressed bytes when metadata/codecs are compatible.
     byte[]? encoded = await array.ReadChunkEncodedAsync(chunk);
     if (encoded is not null)

--- a/S3ZarrStore.cs
+++ b/S3ZarrStore.cs
@@ -390,15 +390,21 @@ public sealed class S3ZarrStore : IZarrStore
 
     public async Task WriteAsync(string key, byte[] data, CancellationToken ct = default)
     {
+        await WriteAsync(key, data.AsMemory(), ct).ConfigureAwait(false);
+    }
+
+    public async Task WriteAsync(string key, ReadOnlyMemory<byte> data, CancellationToken ct = default)
+    {
         ThrowIfDisposed();
 
         var s3Key = BuildS3Key(key);
+        var bytes = data.ToArray();
 
         var request = new PutObjectRequest
         {
             BucketName  = _bucketName,
             Key         = s3Key,
-            InputStream = new MemoryStream(data)
+            InputStream = new MemoryStream(bytes)
         };
 
         await _s3Client.PutObjectAsync(request, ct).ConfigureAwait(false);
@@ -406,9 +412,9 @@ public sealed class S3ZarrStore : IZarrStore
         // Update caches
         var cacheKey = BuildCacheKey(key);
         if (IsMetadataKey(key))
-            s_metadataCache[cacheKey] = data;
+            s_metadataCache[cacheKey] = bytes;
         else
-            GetChunkCache().Set(cacheKey, data);
+            GetChunkCache().Set(cacheKey, bytes);
     }
 
     // =========================================================================

--- a/S3ZarrStore.cs
+++ b/S3ZarrStore.cs
@@ -370,7 +370,7 @@ public sealed class S3ZarrStore : IZarrStore
                 s_metadataCache[cacheKey] = null;
             return null;
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             // Fixed: condition was inverted (retry < 3 returned null immediately,
             // then looped forever once retry exceeded 3 because it was an instance
@@ -494,7 +494,7 @@ public sealed class S3ZarrStore : IZarrStore
                     results.Add(relativeKey);
             }
 
-            continuation = response.IsTruncated.Value ? response.NextContinuationToken : null;
+            continuation = response.IsTruncated == true ? response.NextContinuationToken : null;
         }
         while (continuation is not null);
 

--- a/ZCT.cs
+++ b/ZCT.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace ZarrNET.Core
 {
-    public struct ZCT
+    public struct ZCT : IEquatable<ZCT>
     {
         public int Z, C, T;
         public ZCT(int z, int c, int t)
@@ -27,6 +27,22 @@ namespace ZarrNET.Core
             else
                 return true;
         }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is ZCT other && Equals(other);
+        }
+
+        public bool Equals(ZCT other)
+        {
+            return Z == other.Z && C == other.C && T == other.T;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Z, C, T);
+        }
+
         public override string ToString()
         {
             return Z + "," + C + "," + T;

--- a/ZarrArray.cs
+++ b/ZarrArray.cs
@@ -228,6 +228,67 @@ public sealed class ZarrArray
     }
 
     /// <summary>
+    /// Reads a full logical chunk into caller-owned memory. The destination must be
+    /// at least the full effective chunk byte count. When <paramref name="allowBorrowedBuffer"/>
+    /// is true and the codec pipeline is a no-op bytes path, the store may read
+    /// directly into <paramref name="destination"/>.
+    /// </summary>
+    public async Task ReadChunkDecodedAsync(
+        ZarrChunkRef chunk,
+        Memory<byte> destination,
+        bool allowBorrowedBuffer,
+        CancellationToken ct = default)
+    {
+        ValidateChunkRef(chunk);
+
+        var expectedBytes = checked((int)(_chunkElementCount * Metadata.DataType.ElementSize));
+        if (destination.Length < expectedBytes)
+            throw new ArgumentException(
+                $"Destination has {destination.Length} bytes, expected at least {expectedBytes} bytes " +
+                $"for full chunk shape [{string.Join(", ", _chunkShapeLong)}].",
+                nameof(destination));
+
+        var chunkDestination = destination[..expectedBytes];
+
+        if (allowBorrowedBuffer
+            && Metadata.Sharding is null
+            && _pipeline.CanStoreDecodedBytesWithoutTransform)
+        {
+            var key = BuildChunkContainingStoreKey(chunk.ChunkCoord);
+            var bytesRead = await _store.ReadAsync(key, chunkDestination, ct).ConfigureAwait(false);
+
+            if (bytesRead is null)
+            {
+                BuildFillValueChunk().CopyTo(chunkDestination);
+                return;
+            }
+
+            if (bytesRead.Value == expectedBytes)
+                return;
+
+            var normalized = PadOrValidateDecodedChunk(
+                chunkDestination[..bytesRead.Value].ToArray(),
+                chunk.ChunkCoord);
+            normalized.CopyTo(chunkDestination);
+            return;
+        }
+
+        var decoded = await ReadChunkDecodedAsync(chunk, ct).ConfigureAwait(false);
+        decoded.CopyTo(chunkDestination);
+    }
+
+    public Task ReadChunkDecodedAsync(
+        long[] chunkCoord,
+        Memory<byte> destination,
+        bool allowBorrowedBuffer,
+        CancellationToken ct = default)
+        => ReadChunkDecodedAsync(
+            BuildChunkRef(chunkCoord),
+            destination,
+            allowBorrowedBuffer,
+            ct);
+
+    /// <summary>
     /// Encodes and writes a full logical chunk without read-modify-write.
     /// The input must be a full effective chunk buffer, including fill-value
     /// padding for any edge region outside the array extent.
@@ -239,6 +300,7 @@ public sealed class ZarrArray
         => await WriteChunkDecodedAsync(
             chunk,
             decodedData.AsMemory(),
+            allowBorrowedBuffer: false,
             ct).ConfigureAwait(false);
 
     /// <summary>
@@ -250,6 +312,23 @@ public sealed class ZarrArray
     public async Task WriteChunkDecodedAsync(
         ZarrChunkRef chunk,
         ReadOnlyMemory<byte> decodedData,
+        CancellationToken ct = default)
+        => await WriteChunkDecodedAsync(
+            chunk,
+            decodedData,
+            allowBorrowedBuffer: false,
+            ct).ConfigureAwait(false);
+
+    /// <summary>
+    /// Encodes and writes a full logical chunk without read-modify-write.
+    /// When <paramref name="allowBorrowedBuffer"/> is true and the codec pipeline is
+    /// a no-op bytes path, caller-owned memory is consumed directly by the store
+    /// before this task completes.
+    /// </summary>
+    public async Task WriteChunkDecodedAsync(
+        ZarrChunkRef chunk,
+        ReadOnlyMemory<byte> decodedData,
+        bool allowBorrowedBuffer,
         CancellationToken ct = default)
     {
         if (Metadata.Sharding is not null)
@@ -265,11 +344,29 @@ public sealed class ZarrArray
                 $"for full chunk shape [{string.Join(", ", _chunkShapeLong)}].",
                 nameof(decodedData));
 
+        if (allowBorrowedBuffer && _pipeline.CanStoreDecodedBytesWithoutTransform)
+        {
+            var key = BuildChunkContainingStoreKey(chunk.ChunkCoord);
+            await _store.WriteAsync(key, decodedData, ct).ConfigureAwait(false);
+            return;
+        }
+
         await WriteChunkAsync(
             chunk.ChunkCoord,
             ToExactArray(decodedData),
             ct).ConfigureAwait(false);
     }
+
+    public Task WriteChunkDecodedAsync(
+        long[] chunkCoord,
+        ReadOnlyMemory<byte> decodedData,
+        bool allowBorrowedBuffer,
+        CancellationToken ct = default)
+        => WriteChunkDecodedAsync(
+            BuildChunkRef(chunkCoord),
+            decodedData,
+            allowBorrowedBuffer,
+            ct);
 
     /// <summary>
     /// Reads the encoded bytes for a non-sharded chunk directly from the store.
@@ -315,7 +412,7 @@ public sealed class ZarrArray
         ValidateChunkRef(chunk);
 
         var key = BuildChunkContainingStoreKey(chunk.ChunkCoord);
-        await _store.WriteAsync(key, ToExactArray(encodedData), ct).ConfigureAwait(false);
+        await _store.WriteAsync(key, encodedData, ct).ConfigureAwait(false);
     }
 
     // -------------------------------------------------------------------------

--- a/ZarrArray.cs
+++ b/ZarrArray.cs
@@ -343,7 +343,7 @@ public sealed class ZarrArray
     {
         var key = BuildChunkKey(chunkCoord);
         await s_globalFetchSemaphore.WaitAsync(ct).ConfigureAwait(false);
-        byte[] bytes;
+        byte[]? bytes;
         try
         {
             bytes = await _store.ReadAsync(key, ct).ConfigureAwait(false);


### PR DESCRIPTION
So I:
- Removed duplicate using in OmeZarrWriter.cs
- Added Equals / GetHashCode for ZCT
- Removed unused exception variables
- Fixed nullable handling for store reads and S3 listing
- Marked ReadTileAsync as returning RegionResult since it intentionally returns null for out-of-bounds tiles
- Guarded .zarray diagnostic decoding against null
- Initialised the static guide field with null! to satisfy nullable analysis

Compiling warnings fixed:

  Zarr.NET net10.0 succeeded with 11 warning(s) (1,4s) → bin/Debug/net10.0/ZarrNET.dll /Users/jrh630/repositories/Zarr.NET/OmeZarrWriter.cs(5,7): warning CS0105: The using directive for 'ZarrNET.Core' appeared previously in this namespace /Users/jrh630/repositories/Zarr.NET/ZCT.cs(7,19): warning CS0660: 'ZCT' defines operator == or operator != but does not override Object.Equals(object o) /Users/jrh630/repositories/Zarr.NET/ZCT.cs(7,19): warning CS0661: 'ZCT' defines operator == or operator != but does not override Object.GetHashCode() /Users/jrh630/repositories/Zarr.NET/HttpZarrStore.cs(209,38): warning CS0168: The variable 'ex' is declared but never used /Users/jrh630/repositories/Zarr.NET/S3ZarrStore.cs(373,26): warning CS0168: The variable 'ex' is declared but never used /Users/jrh630/repositories/Zarr.NET/S3ZarrStore.cs(497,28): warning CS8629: Nullable value type may be null. /Users/jrh630/repositories/Zarr.NET/OmeZarrNodes.cs(260,56): warning CS8603: Possible null reference return. /Users/jrh630/repositories/Zarr.NET/OmeZarrNodes.cs(263,56): warning CS8603: Possible null reference return. /Users/jrh630/repositories/Zarr.NET/DiagnoseChunkFiles.cs(46,70): warning CS8604: Possible null reference argument for parameter 'bytes' in 'string Encoding.GetString(byte[] bytes)'. /Users/jrh630/repositories/Zarr.NET/ZarrArray.cs(349,21): warning CS8600: Converting null literal or possible null value to non-nullable type. /Users/jrh630/repositories/Zarr.NET/PropertyReferenceGuide.cs(16,38): warning CS8618: Non-nullable field 'image' must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring the field as nullable.